### PR TITLE
Bump dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "component-emitter": "^1.2.1",
     "get-value": "^2.0.5",
     "has-value": "^0.3.1",
-    "isobject": "^2.1.0",
+    "isobject": "^3.0.0",
     "lazy-cache": "^2.0.1",
     "set-value": "^0.3.3",
     "to-object-path": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "has-value": "^0.3.1",
     "isobject": "^3.0.0",
     "lazy-cache": "^2.0.1",
-    "set-value": "^0.3.3",
+    "set-value": "^0.4.2",
     "to-object-path": "^0.3.0",
     "union-value": "^0.2.3",
     "unset-value": "^0.1.1"


### PR DESCRIPTION
For https://github.com/jonschlinkert/snapdragon/issues/6.
The `isobject` bump and the `set-value` bump are in separate commits; I can split this into two PR's if you would like.