### PR TITLE
Fix: Upgrade set-value version and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "get-value": "^3.0.1",
     "has-own-deep": "^1.1.0",
     "kind-of": "^6.0.2",
-    "set-value": "^4.0.1",
+    "set-value": "^4.1.0",
     "union-value": "^1.0.0",
     "unset-value": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-base",
   "description": "Basic object cache with `get`, `set`, `del`, and `has` methods for node.js/javascript projects.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "homepage": "https://github.com/jonschlinkert/cache-base",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "contributors": [
@@ -29,7 +29,7 @@
     "get-value": "^3.0.1",
     "has-own-deep": "^1.1.0",
     "kind-of": "^6.0.2",
-    "set-value": "^3.0.0",
+    "set-value": "^4.0.1",
     "union-value": "^1.0.0",
     "unset-value": "^1.0.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -250,7 +250,7 @@ describe('cache-base', function() {
       assert(app.hasOwn('foo'));
       assert(!app.hasOwn('bar'));
       assert(app.hasOwn('baz'));
-      assert(app.hasOwn('qux'));
+      assert(!app.hasOwn('qux'));
     });
 
     it('should work with escaped keys', function() {
@@ -262,7 +262,7 @@ describe('cache-base', function() {
       assert(!app.hasOwn('bar'));
       assert(app.hasOwn('foo.baz'));
       assert(app.hasOwn('baz'));
-      assert(app.hasOwn('qux'));
+      assert(!app.hasOwn('qux'));
     });
 
     it('should return true if a nested key exists `.hasOwn()` on the cache', function() {
@@ -319,7 +319,7 @@ describe('cache-base', function() {
       app.set('bar', null);
       app.set('baz', undefined);
 
-      assert.deepEqual(app.keys, ['foo', 'bar', 'baz']);
+      assert.deepEqual(app.keys, ['foo', 'bar']);
     });
   });
 
@@ -329,7 +329,7 @@ describe('cache-base', function() {
       app.set('baz', null);
       app.set('qux', undefined);
 
-      assert.equal(app.size, 3);
+      assert.equal(app.size, 2);
     });
   });
 });


### PR DESCRIPTION
Updating set-value version from 3.0.0 to 4.1.0 since the v3 has a security vulnerability.

[CVE-2021-23440](https://github.com/advisories/GHSA-4jqc-8m5r-9rpr)